### PR TITLE
Add barbell orbit animation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 scipy
 pyyaml
 matplotlib
+pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ numpy
 scipy
 pyyaml
 matplotlib
-pillow

--- a/sims/run_leo_100km.py
+++ b/sims/run_leo_100km.py
@@ -11,7 +11,7 @@ import yaml
 from tskb import BangBangController, DualBarbell, Environment, plotting, run_simulation
 
 
-def main(cfg_path: str) -> dict:
+def main(cfg_path: str, animate: bool = False) -> dict:
     with open(cfg_path, "r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
     env = Environment()
@@ -26,11 +26,14 @@ def main(cfg_path: str) -> dict:
         for t, r, v, p in zip(log["t"], log["r"], log["v"], log["power_control"]):
             writer.writerow([t, *r, *v, p])
     plotting.quicklook(log, os.path.join("outputs", "leo_100km.png"))
+    if animate:
+        plotting.animate_barbell(log, os.path.join("outputs", "leo_100km.gif"))
     return log
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", required=True)
+    parser.add_argument("--animate", action="store_true", help="save animation GIF")
     args = parser.parse_args()
-    main(args.config)
+    main(args.config, animate=args.animate)

--- a/sims/run_leo_100km.py
+++ b/sims/run_leo_100km.py
@@ -27,13 +27,13 @@ def main(cfg_path: str, animate: bool = False) -> dict:
             writer.writerow([t, *r, *v, p])
     plotting.quicklook(log, os.path.join("outputs", "leo_100km.png"))
     if animate:
-        plotting.animate_barbell(log, os.path.join("outputs", "leo_100km.gif"))
+        plotting.animate_barbell(log, os.path.join("outputs", "leo_100km.mp4"))
     return log
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", required=True)
-    parser.add_argument("--animate", action="store_true", help="save animation GIF")
+    parser.add_argument("--animate", action="store_true", help="save animation MP4")
     args = parser.parse_args()
     main(args.config, animate=args.animate)

--- a/src/tskb/integrate.py
+++ b/src/tskb/integrate.py
@@ -50,8 +50,14 @@ def run_simulation(env, craft, ctrl, cfg: dict) -> dict:
 
     r = sol.y[0:3, :].T
     v = sol.y[3:6, :].T
+    theta = sol.y[6, :]
     length = sol.y[8, :]
     length_rate = sol.y[9, :]
+
+    # Positions of the endpoint masses for convenience
+    u = np.vstack([np.cos(theta), np.sin(theta), np.zeros_like(theta)]).T
+    r1 = r + 0.5 * length[:, None] * u
+    r2 = r - 0.5 * length[:, None] * u
 
     power_control = np.zeros_like(sol.t)
     for i, (t, L, Ldot) in enumerate(zip(sol.t, length, length_rate)):
@@ -63,7 +69,10 @@ def run_simulation(env, craft, ctrl, cfg: dict) -> dict:
         "t": sol.t,
         "r": r,
         "v": v,
+        "theta": theta,
         "length": length,
         "length_rate": length_rate,
+        "r1": r1,
+        "r2": r2,
         "power_control": power_control,
     }

--- a/src/tskb/plotting.py
+++ b/src/tskb/plotting.py
@@ -29,7 +29,7 @@ def animate_barbell(log: dict, path: str, interval: int = 200) -> None:
     log : dict
         Output dictionary from :func:`run_simulation`.
     path : str
-        Output filename for the GIF animation.
+        Output filename for the MP4 animation. Requires ``ffmpeg`` to be installed.
     interval : int
         Delay between frames in milliseconds.
     """
@@ -81,6 +81,6 @@ def animate_barbell(log: dict, path: str, interval: int = 200) -> None:
         return mass1, mass2, connector
 
     ani = animation.FuncAnimation(fig, update, frames=len(log["t"]), interval=interval, blit=False)
-    writer = animation.PillowWriter(fps=max(1, int(1000 / interval)))
+    writer = animation.FFMpegWriter(fps=max(1, int(1000 / interval)))
     ani.save(path, writer=writer)
     plt.close(fig)

--- a/src/tskb/plotting.py
+++ b/src/tskb/plotting.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib import animation
 
 from .diagnostics import semimajor_axis
 
@@ -17,3 +19,68 @@ def quicklook(log: dict, path: str) -> None:
     plt.tight_layout()
     plt.savefig(path)
     plt.close()
+
+
+def animate_barbell(log: dict, path: str, interval: int = 200) -> None:
+    """Animate barbell motion about Earth.
+
+    Parameters
+    ----------
+    log : dict
+        Output dictionary from :func:`run_simulation`.
+    path : str
+        Output filename for the GIF animation.
+    interval : int
+        Delay between frames in milliseconds.
+    """
+
+    r = log["r"]
+    theta = log["theta"]
+    length = log["length"]
+
+    u = np.vstack([np.cos(theta), np.sin(theta), np.zeros_like(theta)]).T
+    r1 = r + 0.5 * length[:, None] * u
+    r2 = r - 0.5 * length[:, None] * u
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+
+    # Earth represented as a translucent sphere
+    R_EARTH = 6378e3
+    u_s = np.linspace(0, 2 * np.pi, 30)
+    v_s = np.linspace(0, np.pi, 15)
+    x = R_EARTH * np.outer(np.cos(u_s), np.sin(v_s))
+    y = R_EARTH * np.outer(np.sin(u_s), np.sin(v_s))
+    z = R_EARTH * np.outer(np.ones_like(u_s), np.cos(v_s))
+    ax.plot_surface(x, y, z, color="b", alpha=0.3, linewidth=0)
+    ax.scatter([0], [0], [0], color="k", s=10)
+
+    mass1, = ax.plot([], [], [], "ro")
+    mass2, = ax.plot([], [], [], "ro")
+    connector, = ax.plot([], [], [], "k-", lw=1)
+
+    all_pos = np.vstack([r1, r2])
+    limit = np.max(np.abs(all_pos))
+    ax.set_xlim(-limit, limit)
+    ax.set_ylim(-limit, limit)
+    ax.set_zlim(-limit, limit)
+    ax.set_box_aspect((1, 1, 1))
+    ax.set_xlabel("x [m]")
+    ax.set_ylabel("y [m]")
+    ax.set_zlabel("z [m]")
+
+    def update(i: int):
+        p1 = r1[i]
+        p2 = r2[i]
+        mass1.set_data([p1[0]], [p1[1]])
+        mass1.set_3d_properties([p1[2]])
+        mass2.set_data([p2[0]], [p2[1]])
+        mass2.set_3d_properties([p2[2]])
+        connector.set_data([p1[0], p2[0]], [p1[1], p2[1]])
+        connector.set_3d_properties([p1[2], p2[2]])
+        return mass1, mass2, connector
+
+    ani = animation.FuncAnimation(fig, update, frames=len(log["t"]), interval=interval, blit=False)
+    writer = animation.PillowWriter(fps=max(1, int(1000 / interval)))
+    ani.save(path, writer=writer)
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- log barbell orientation and endpoint positions during simulation
- add 3D barbell animation utility with Earth sphere
- expose `--animate` option in LEO example to save GIF

## Testing
- `python -m pip install -r requirements.txt`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5bf4014988322a069116b0e1261dc