### PR TITLE
Add passive controller and configurable spin modes

### DIFF
--- a/configs/leo_100km.yaml
+++ b/configs/leo_100km.yaml
@@ -1,7 +1,9 @@
 mass: 1000.0
 altitude_m: 200000.0
 length0: 100000.0
+omega0: tidally_locked  # tidally_locked, no_rotation, prograde, retrograde
 controller:
+  type: bang_bang
   extend_accel: 0.01      # m/s^2
   retract_accel: 0.01     # m/s^2
   delta_phase_deg: 0.0

--- a/configs/leo_10km.yaml
+++ b/configs/leo_10km.yaml
@@ -1,7 +1,9 @@
 mass: 1000.0
 altitude_m: 10000.0
 length0: 1000.0
+omega0: tidally_locked  # tidally_locked, no_rotation, prograde, retrograde
 controller:
+  type: bang_bang
   extend_accel: 0.001      # m/s^2
   retract_accel: 0.001     # m/s^2
   delta_phase_deg: 0.0

--- a/configs/leo_50km.yaml
+++ b/configs/leo_50km.yaml
@@ -1,7 +1,9 @@
 mass: 1000.0
 altitude_m: 50000.0
 length0: 1000.0
+omega0: tidally_locked  # tidally_locked, no_rotation, prograde, retrograde
 controller:
+  type: bang_bang
   extend_accel: 0.001      # m/s^2
   retract_accel: 0.001     # m/s^2
   delta_phase_deg: 0.0

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -214,6 +214,7 @@ barbells:
   pretension_N: 500.0
   spin_rad_s: 0.0         # net spin ≈ 0 via counter‑rotation
 controller:
+  type: bang_bang
   extend_accel: 0.001    # m/s^2
   retract_accel: 0.001   # m/s^2
   delta_phase_deg: 10.0

--- a/sims/run_leo_100km.py
+++ b/sims/run_leo_100km.py
@@ -8,7 +8,7 @@ import os
 
 import yaml
 
-from tskb import BangBangController, DualBarbell, Environment, plotting, run_simulation
+from tskb import DualBarbell, Environment, make_controller, plotting, run_simulation
 
 
 def main(cfg_path: str, animate: bool = False) -> dict:
@@ -16,7 +16,7 @@ def main(cfg_path: str, animate: bool = False) -> dict:
         cfg = yaml.safe_load(f)
     env = Environment()
     craft = DualBarbell(cfg["mass"])
-    ctrl = BangBangController(cfg["controller"])
+    ctrl = make_controller(cfg["controller"])
     log = run_simulation(env, craft, ctrl, cfg)
     os.makedirs("outputs", exist_ok=True)
     out_csv = os.path.join("outputs", "leo_100km.csv")

--- a/src/tskb/__init__.py
+++ b/src/tskb/__init__.py
@@ -2,7 +2,7 @@
 
 from .env import Environment
 from .barbell import DualBarbell, Q_of_barbell
-from .controller import BangBangController
+from .controller import BangBangController, PassiveController, make_controller
 from .integrate import run_simulation
 from . import diagnostics
 
@@ -11,6 +11,8 @@ __all__ = [
     "DualBarbell",
     "Q_of_barbell",
     "BangBangController",
+    "PassiveController",
+    "make_controller",
     "run_simulation",
     "diagnostics",
 ]

--- a/src/tskb/controller.py
+++ b/src/tskb/controller.py
@@ -43,3 +43,28 @@ class BangBangController(Controller):
         if abs(angdiff(nu, 0.0)) < self.nu_window:
             return -self.retract_accel
         return 0.0
+
+
+class PassiveController(Controller):
+    """Controller that commands no tether acceleration."""
+
+    def action(self, t: float, state: np.ndarray) -> float:
+        return 0.0
+
+
+def make_controller(cfg: dict) -> Controller:
+    """Instantiate a controller from ``cfg``.
+
+    Parameters
+    ----------
+    cfg : dict
+        Controller configuration with a ``type`` key specifying
+        ``"bang_bang"`` or ``"passive"``.
+    """
+
+    ctrl_type = cfg.get("type", "bang_bang").lower()
+    if ctrl_type == "bang_bang":
+        return BangBangController(cfg)
+    if ctrl_type == "passive":
+        return PassiveController()
+    raise ValueError(f"unknown controller type: {ctrl_type}")

--- a/src/tskb/dynamics.py
+++ b/src/tskb/dynamics.py
@@ -59,9 +59,9 @@ def f_state(t: float, y: np.ndarray, env, craft, ctrl) -> np.ndarray:
     tau_vec = 0.5 * L_eff * np.cross(u_vec, F1 - F2)
     tau = tau_vec[2]
 
-    I = craft.mass * L_eff**2 / 4.0
-    I_dot = craft.mass * L_eff * Ldot / 2.0
-    omega_dot = (tau - I_dot * omega) / I
+    inertia = craft.mass * L_eff**2 / 4.0
+    inertia_dot = craft.mass * L_eff * Ldot / 2.0
+    omega_dot = (tau - inertia_dot * omega) / inertia
 
     theta_dot = omega
     return np.hstack([v, a_com, theta_dot, omega_dot, Ldot, L_ddot])

--- a/src/tskb/integrate.py
+++ b/src/tskb/integrate.py
@@ -21,7 +21,19 @@ def run_simulation(env, craft, ctrl, cfg: dict) -> dict:
 
     # Initial orientation/length state
     theta0 = cfg.get("theta0", 0.0)
-    omega0 = cfg.get("omega0", n0)
+    omega_cfg = cfg.get("omega0", "tidally_locked")
+    if isinstance(omega_cfg, str):
+        modes = {
+            "tidally_locked": n0,
+            "no_rotation": 0.0,
+            "prograde": 2.0 * n0,
+            "retrograde": -1.0 * n0,
+        }
+        if omega_cfg not in modes:
+            raise ValueError(f"unknown omega0 mode: {omega_cfg}")
+        omega0 = modes[omega_cfg]
+    else:
+        omega0 = float(omega_cfg)
     L0 = cfg.get("length0", 1000.0)
     Ldot0 = cfg.get("length_rate0", 0.0)
 
@@ -51,6 +63,7 @@ def run_simulation(env, craft, ctrl, cfg: dict) -> dict:
     r = sol.y[0:3, :].T
     v = sol.y[3:6, :].T
     theta = sol.y[6, :]
+    omega = sol.y[7, :]
     length = sol.y[8, :]
     length_rate = sol.y[9, :]
 
@@ -65,6 +78,7 @@ def run_simulation(env, craft, ctrl, cfg: dict) -> dict:
         "r": r,
         "v": v,
         "theta": theta,
+        "omega": omega,
         "length": length,
         "length_rate": length_rate,
         "power_control": power_control,

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -1,4 +1,6 @@
-import subprocess, sys, os
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 def test_leo_100km_cli_completes_under_timeout():

--- a/tests/test_controller_interface.py
+++ b/tests/test_controller_interface.py
@@ -1,10 +1,11 @@
 import numpy as np
-from tskb.controller import BangBangController
+from tskb.controller import BangBangController, PassiveController
 
 
 def test_controller_action_interface():
     cfg = {"extend_accel": 1.0, "retract_accel": 1.0}
-    ctrl = BangBangController(cfg)
     state = np.zeros(10)
-    action = ctrl.action(0.0, state)
+    action = BangBangController(cfg).action(0.0, state)
+    assert isinstance(action, float)
+    action = PassiveController().action(0.0, state)
     assert isinstance(action, float)

--- a/tests/test_initial_spin_modes.py
+++ b/tests/test_initial_spin_modes.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+from tskb import Environment, DualBarbell, make_controller, run_simulation
+
+@pytest.mark.parametrize(
+    "mode, factor",
+    [
+        ("tidally_locked", 1.0),
+        ("no_rotation", 0.0),
+        ("prograde", 2.0),
+        ("retrograde", -1.0),
+    ],
+)
+def test_initial_spin_modes(mode, factor):
+    cfg = {
+        "mass": 1000.0,
+        "altitude_m": 200000.0,
+        "length0": 1000.0,
+        "omega0": mode,
+        "controller": {"type": "passive"},
+        "integrator": {"t_final": 1.0, "dt_output": 1.0},
+    }
+    env = Environment()
+    craft = DualBarbell(cfg["mass"])
+    ctrl = make_controller(cfg["controller"])
+    log = run_simulation(env, craft, ctrl, cfg)
+    r0 = 6378e3 + cfg["altitude_m"]
+    n0 = np.sqrt(env.mu_earth / r0**3)
+    assert np.isclose(log["omega"][0], factor * n0)

--- a/tests/test_leo_yaml_config.py
+++ b/tests/test_leo_yaml_config.py
@@ -3,7 +3,7 @@ import yaml
 import numpy as np
 from pathlib import Path
 
-from tskb import Environment, DualBarbell, BangBangController, run_simulation
+from tskb import Environment, DualBarbell, make_controller, run_simulation
 
 
 def test_yaml_config_simulates():
@@ -15,7 +15,7 @@ def test_yaml_config_simulates():
     cfg["integrator"]["dt_output"] = 10.0
     env = Environment()
     craft = DualBarbell(cfg["mass"])
-    ctrl = BangBangController(cfg["controller"])
+    ctrl = make_controller(cfg["controller"])
     log = run_simulation(env, craft, ctrl, cfg)
     assert log["t"][0] == 0.0
     assert log["t"][-1] == cfg["integrator"]["t_final"]


### PR DESCRIPTION
## Summary
- Add a `PassiveController` and `make_controller` factory for swapping controller implementations
- Allow `omega0` to be configured with named spin modes and expose barbell spin in simulation logs
- Update configs, CLI, docs and tests for new controller and spin options

## Testing
- `ruff check src sims tests`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a692289ea083229e1e717f31e60809