### PR TITLE
Add semimajor-axis growth FOM and scenario sweep

### DIFF
--- a/sims/run_fom_scenarios.py
+++ b/sims/run_fom_scenarios.py
@@ -1,0 +1,59 @@
+"""Run scenarios and compute semimajor-axis growth figure of merit."""
+
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import yaml
+
+from tskb import Environment, DualBarbell, make_controller, run_simulation
+from tskb import diagnostics
+
+
+MONTH = 30 * 24 * 3600.0
+ORBIT_BUFFER = 6000.0
+
+
+def run_case(base_cfg: dict, omega0, ctrl_type: str) -> float:
+    """Run a single scenario and return the semimajor-axis FOM."""
+
+    cfg = copy.deepcopy(base_cfg)
+    cfg["omega0"] = omega0
+    cfg["controller"]["type"] = ctrl_type
+    cfg["integrator"]["t_final"] = MONTH + ORBIT_BUFFER
+
+    env = Environment()
+    craft = DualBarbell(cfg["mass"])
+    ctrl = make_controller(cfg["controller"])
+    log = run_simulation(env, craft, ctrl, cfg)
+    return diagnostics.semimajor_axis_fom(log)
+
+
+def main() -> None:
+    with open("configs/leo_100km.yaml", "r", encoding="utf-8") as f:
+        base_cfg = yaml.safe_load(f)
+
+    env = Environment()
+    r0 = 6378e3 + base_cfg["altitude_m"]
+    n0 = np.sqrt(env.mu_earth / r0**3)
+
+    spin_modes = [
+        ("tidally_locked", "tidally_locked"),
+        ("no_rotation", "no_rotation"),
+        ("prograde", "prograde"),
+        ("retrograde", "retrograde"),
+        ("1.5n0", 1.5 * n0),
+    ]
+    ctrl_types = ["bang_bang", "passive"]
+
+    print(f"{'omega0':<15}{'controller':<12}{'FOM (m)':>10}")
+    for label, omega in spin_modes:
+        for ctrl_type in ctrl_types:
+            fom = run_case(base_cfg, omega, ctrl_type)
+            print(f"{label:<15}{ctrl_type:<12}{fom:>10.3f}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation script
+    main()
+

--- a/src/tskb/diagnostics.py
+++ b/src/tskb/diagnostics.py
@@ -18,3 +18,60 @@ def semimajor_axis(log: dict, idx: int) -> float:
 
 def mean_power_from_tide(log: dict) -> float:
     return float(np.mean(log["power_tide"]))
+
+
+def _semimajor_axis_from_rv(r: np.ndarray, v: np.ndarray) -> np.ndarray:
+    """Return semimajor axis from position/velocity vectors.
+
+    Parameters
+    ----------
+    r : np.ndarray
+        Position vectors with shape (..., 3).
+    v : np.ndarray
+        Velocity vectors with shape (..., 3).
+    """
+
+    rmag = np.linalg.norm(r, axis=-1)
+    vmag2 = np.sum(v * v, axis=-1)
+    return 1.0 / (2.0 / rmag - vmag2 / MU_EARTH)
+
+
+def orbit_period(log: dict, idx: int = 0) -> float:
+    """Estimate orbital period from state ``idx``."""
+
+    a0 = _semimajor_axis_from_rv(log["r"][idx], log["v"][idx])
+    return 2 * np.pi * np.sqrt(a0**3 / MU_EARTH)
+
+
+def orbit_averaged_semimajor_axis(
+    log: dict, start_time: float, period: float
+) -> float:
+    """Average semimajor axis over one full orbit.
+
+    Integrates the osculating semimajor axis between ``start_time`` and
+    ``start_time + period`` using a trapezoidal rule.
+    """
+
+    t = log["t"]
+    r = log["r"]
+    v = log["v"]
+    mask = (t >= start_time) & (t <= start_time + period)
+    if np.count_nonzero(mask) < 2:
+        raise ValueError("insufficient samples for orbit averaging")
+    a = _semimajor_axis_from_rv(r[mask], v[mask])
+    tt = t[mask]
+    return float(np.trapz(a, tt) / (tt[-1] - tt[0]))
+
+
+def semimajor_axis_fom(log: dict, month: float = 30 * 24 * 3600.0) -> float:
+    """Figure of merit: growth in orbit-averaged semimajor axis.
+
+    The value returned is the difference between the semimajor axis
+    averaged over the first orbit and the semimajor axis averaged over
+    one orbit after ``month`` seconds of simulation time.
+    """
+
+    period = orbit_period(log)
+    a_start = orbit_averaged_semimajor_axis(log, 0.0, period)
+    a_month = orbit_averaged_semimajor_axis(log, month, period)
+    return a_month - a_start


### PR DESCRIPTION
## Summary
- Add utilities to compute orbit-averaged semimajor axis and a figure of merit after a month
- Provide script to sweep spin rate and controller combinations and print FOM table

## Testing
- `pre-commit run --files src/tskb/diagnostics.py sims/run_fom_scenarios.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9b1bd08608322a578c0f9fbf3cce5