### PR TITLE
Add theta0 configuration parameter and sweep support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ expected to be cornerstones of sustained economic activity beyond Earth.
    ```
    produces a sweep over boom length. Use `plotting.quicklook` or custom analysis on the CSV logs for other plots.
 
+Configuration files also accept a `theta0` field (radians) that sets the starting barbell angle.
+Adjust this value—or supply a list when using `sims/run_fom_scenarios.py`—to explore different
+initial orientations.
+
 For a detailed project overview and development roadmap see `docs/overview.md` and `docs/roadmap.md`.
 
 # Repository: `tidal-station-keeping-barbell`

--- a/configs/leo_100km.yaml
+++ b/configs/leo_100km.yaml
@@ -2,6 +2,7 @@ mass: 1000.0
 altitude_m: 200000.0
 length0: 100000.0
 omega0: tidally_locked  # tidally_locked, no_rotation, prograde, retrograde
+theta0: 0.0            # radians
 controller:
   type: bang_bang
   extend_accel: 0.01      # m/s^2

--- a/configs/leo_10km.yaml
+++ b/configs/leo_10km.yaml
@@ -2,6 +2,7 @@ mass: 1000.0
 altitude_m: 10000.0
 length0: 1000.0
 omega0: tidally_locked  # tidally_locked, no_rotation, prograde, retrograde
+theta0: 0.0            # radians
 controller:
   type: bang_bang
   extend_accel: 0.001      # m/s^2

--- a/configs/leo_50km.yaml
+++ b/configs/leo_50km.yaml
@@ -2,6 +2,7 @@ mass: 1000.0
 altitude_m: 50000.0
 length0: 1000.0
 omega0: tidally_locked  # tidally_locked, no_rotation, prograde, retrograde
+theta0: 0.0            # radians
 controller:
   type: bang_bang
   extend_accel: 0.001      # m/s^2

--- a/sims/run_fom_scenarios.py
+++ b/sims/run_fom_scenarios.py
@@ -15,11 +15,12 @@ MONTH = 30 * 24 * 3600.0
 ORBIT_BUFFER = 6000.0
 
 
-def run_case(base_cfg: dict, omega0, ctrl_type: str) -> float:
+def run_case(base_cfg: dict, omega0, ctrl_type: str, theta0: float) -> float:
     """Run a single scenario and return the semimajor-axis FOM."""
 
     cfg = copy.deepcopy(base_cfg)
     cfg["omega0"] = omega0
+    cfg["theta0"] = theta0
     cfg["controller"]["type"] = ctrl_type
     cfg["integrator"]["t_final"] = MONTH + ORBIT_BUFFER
 
@@ -46,12 +47,16 @@ def main() -> None:
         ("1.5n0", 1.5 * n0),
     ]
     ctrl_types = ["bang_bang", "passive"]
+    theta0_values = base_cfg.get("theta0", 0.0)
+    if not isinstance(theta0_values, (list, tuple, np.ndarray)):
+        theta0_values = [theta0_values]
 
-    print(f"{'omega0':<15}{'controller':<12}{'FOM (m)':>10}")
-    for label, omega in spin_modes:
-        for ctrl_type in ctrl_types:
-            fom = run_case(base_cfg, omega, ctrl_type)
-            print(f"{label:<15}{ctrl_type:<12}{fom:>10.3f}")
+    print(f"{'theta0(rad)':<12}{'omega0':<15}{'controller':<12}{'FOM (m)':>10}")
+    for theta0 in theta0_values:
+        for label, omega in spin_modes:
+            for ctrl_type in ctrl_types:
+                fom = run_case(base_cfg, omega, ctrl_type, theta0)
+                print(f"{theta0:<12.3f}{label:<15}{ctrl_type:<12}{fom:>10.3f}")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation script


### PR DESCRIPTION
## Summary
- allow setting initial barbell angle `theta0` in LEO configs
- sweep over lists of `theta0` values in `run_fom_scenarios.py`
- document `theta0` in README and scenario instructions

## Testing
- `pre-commit run --files configs/leo_10km.yaml configs/leo_50km.yaml configs/leo_100km.yaml sims/run_fom_scenarios.py README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa127ef49c8322998b4a4a49735674