### PR TITLE
Align prograde/retrograde spin with lunar vector crossings

### DIFF
--- a/src/tskb/integrate.py
+++ b/src/tskb/integrate.py
@@ -18,6 +18,7 @@ def run_simulation(env, craft, ctrl, cfg: dict) -> dict:
     r0_mag = 6378e3 + alt
     v0_mag = np.sqrt(env.mu_earth / r0_mag)
     n0 = np.sqrt(env.mu_earth / r0_mag**3)
+    n_syn = n0 - env.n_moon
 
     # Initial orientation/length state
     theta0 = cfg.get("theta0", 0.0)
@@ -26,8 +27,8 @@ def run_simulation(env, craft, ctrl, cfg: dict) -> dict:
         modes = {
             "tidally_locked": n0,
             "no_rotation": 0.0,
-            "prograde": 2.0 * n0,
-            "retrograde": -1.0 * n0,
+            "prograde": n0 + n_syn,
+            "retrograde": n0 - n_syn,
         }
         if omega_cfg not in modes:
             raise ValueError(f"unknown omega0 mode: {omega_cfg}")

--- a/tests/test_initial_spin_modes.py
+++ b/tests/test_initial_spin_modes.py
@@ -3,16 +3,9 @@ import pytest
 
 from tskb import Environment, DualBarbell, make_controller, run_simulation
 
-@pytest.mark.parametrize(
-    "mode, factor",
-    [
-        ("tidally_locked", 1.0),
-        ("no_rotation", 0.0),
-        ("prograde", 2.0),
-        ("retrograde", -1.0),
-    ],
-)
-def test_initial_spin_modes(mode, factor):
+
+@pytest.mark.parametrize("mode", ["tidally_locked", "no_rotation", "prograde", "retrograde"])
+def test_initial_spin_modes(mode):
     cfg = {
         "mass": 1000.0,
         "altitude_m": 200000.0,
@@ -27,4 +20,11 @@ def test_initial_spin_modes(mode, factor):
     log = run_simulation(env, craft, ctrl, cfg)
     r0 = 6378e3 + cfg["altitude_m"]
     n0 = np.sqrt(env.mu_earth / r0**3)
-    assert np.isclose(log["omega"][0], factor * n0)
+    n_syn = n0 - env.n_moon
+    expected = {
+        "tidally_locked": n0,
+        "no_rotation": 0.0,
+        "prograde": n0 + n_syn,
+        "retrograde": n0 - n_syn,
+    }[mode]
+    assert np.isclose(log["omega"][0], expected)


### PR DESCRIPTION
## Summary
- Synchronize predefined prograde/retrograde spin modes with the Moon-crossing frequency using synodic rate
- Update initial spin mode test to validate new rates derived from lunar motion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab0d05eb848322a48737271165d862