### PR TITLE
Add config overrides to FOM scenario runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,20 @@ They can be swapped in and out when running scenarios to compare performance.
 - **Run Example**:
 
 ```bash
-  python sims/run_fom_scenarios.py
+  python sims/run_fom_scenarios.py --controller passive
+```
+
+- **Multiple Controllers**: Provide a comma-separated list.
+
+```bash
+  python sims/run_fom_scenarios.py --controller bang_bang,passive
+```
+
+- **Other Config Overrides**: Use `--override key=value1,value2` (dot notation for nested keys) to sweep additional
+  configuration options.
+
+```bash
+  python sims/run_fom_scenarios.py --override mass=500,1000 --override controller.extend_accel=0.02,0.05
 ```
 
 * **Sample Output**:

--- a/sims/run_fom_scenarios.py
+++ b/sims/run_fom_scenarios.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import argparse
 import copy
+import itertools
 
 import numpy as np
 import yaml
@@ -31,7 +33,55 @@ def run_case(base_cfg: dict, omega0, ctrl_type: str, theta0: float) -> float:
     return diagnostics.semimajor_axis_fom(log)
 
 
+def parse_overrides(values: list[str]) -> dict[str, list[object]]:
+    """Parse override strings into a mapping of key paths to values."""
+
+    overrides: dict[str, list[object]] = {}
+    for item in values:
+        if "=" not in item:
+            raise ValueError(f"Invalid override '{item}', expected key=value")
+        key, raw_vals = item.split("=", 1)
+        overrides[key] = [yaml.safe_load(v) for v in raw_vals.split(",") if v]
+    return overrides
+
+
+def set_nested(cfg: dict, keys: list[str], value: object) -> None:
+    """Set ``value`` in ``cfg`` following ``keys`` path."""
+
+    node = cfg
+    for key in keys[:-1]:
+        node = node.setdefault(key, {})
+    node[keys[-1]] = value
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--controller",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated list of controller types to run. "
+            "Defaults to bang_bang,passive."
+        ),
+    )
+    parser.add_argument(
+        "--override",
+        action="append",
+        default=[],
+        help=(
+            "Override config option as key=value1,value2. "
+            "Use dot notation for nested keys. Can be supplied multiple times."
+        ),
+    )
+    return parser.parse_args()
+
+
 def main() -> None:
+    args = parse_args()
+
     with open("configs/leo_100km.yaml", "r", encoding="utf-8") as f:
         base_cfg = yaml.safe_load(f)
 
@@ -46,16 +96,32 @@ def main() -> None:
         ("retrograde", "retrograde"),
         ("1.5n0", 1.5 * n0),
     ]
-    ctrl_types = ["bang_bang", "passive"]
-    theta0_values = base_cfg.get("theta0", 0.0)
-    if not isinstance(theta0_values, (list, tuple, np.ndarray)):
-        theta0_values = [theta0_values]
+    overrides = parse_overrides(args.override)
+    if args.controller:
+        overrides["controller.type"] = [
+            c.strip() for c in args.controller.split(",") if c.strip()
+        ]
+    else:
+        overrides["controller.type"] = ["bang_bang", "passive"]
+
+    keys = list(overrides)
+    value_lists = [overrides[k] for k in keys]
 
     print(f"{'theta0(rad)':<12}{'omega0':<15}{'controller':<12}{'FOM (m)':>10}")
-    for theta0 in theta0_values:
-        for label, omega in spin_modes:
-            for ctrl_type in ctrl_types:
-                fom = run_case(base_cfg, omega, ctrl_type, theta0)
+    for combo in itertools.product(*value_lists):
+        cfg = copy.deepcopy(base_cfg)
+        current = dict(zip(keys, combo))
+        for path, val in current.items():
+            set_nested(cfg, path.split("."), val)
+
+        ctrl_type = current["controller.type"]
+        theta0_values = cfg.get("theta0", 0.0)
+        if not isinstance(theta0_values, (list, tuple, np.ndarray)):
+            theta0_values = [theta0_values]
+
+        for theta0 in theta0_values:
+            for label, omega in spin_modes:
+                fom = run_case(cfg, omega, ctrl_type, theta0)
                 print(f"{theta0:<12.3f}{label:<15}{ctrl_type:<12}{fom:>10.3f}")
 
 

--- a/tests/test_power_filter_stability.py
+++ b/tests/test_power_filter_stability.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tskb.controller import BangBangController
 
 


### PR DESCRIPTION
## Summary
- extend FOM scenario runner with general `--override` CLI accepting comma-separated values for any config option
- document override usage in AGENTS

## Testing
- `ruff check src sims tests`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abad9db4a483228b240dbb652fdf21