### PR TITLE
Add neural controller usage documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,16 @@ They can be swapped in and out when running scenarios to compare performance.
 * **Description**: No active control; the system evolves only under natural dynamics.
 * **Use Case**: Baseline for comparison against active controllers. An active controller may not be needed.
 
+### Neural Net Controller
+
+* **File**: `src/tskb/controller.py`
+* **Description**: Feedforward neural-network policy that maps the full state
+  vector to a tether acceleration command. Parameters are optimized to maximize
+  the semimajor-axis FOM.
+* **Training Script**: `sims/train_nn_controller.py`
+* **Use Case**: Learned control strategies and experimentation with optimized
+  policies.
+
 ## Scenario Runners
 
 ### FOM Scenarios

--- a/docs/neural_controller.md
+++ b/docs/neural_controller.md
@@ -1,0 +1,49 @@
+# Neural-Net Controller Guide
+
+This guide describes how to train the neural-network controller, inspect its Figure of Merit (FOM), and run simulations using the trained weights.
+
+## Train the controller
+
+Run the training script with a base simulation config:
+
+```bash
+PYTHONPATH=src python sims/train_nn_controller.py --iterations 50 --output nn_controller_weights.npy
+```
+
+- `--config` selects the YAML config (default `configs/leo_100km.yaml`).
+- `--output` chooses where to save the best weights. The file is created relative to the current directory unless an absolute path is given.
+- Each iteration prints the candidate and best FOM values so you can monitor progress:
+
+```
+iter 0: FOM=123.4, best=123.4
+iter 1: FOM=120.0, best=123.4
+...
+Saved best parameters to nn_controller_weights.npy
+```
+
+## Use the trained weights
+
+Create a controller configuration that points to the saved weight file:
+
+```yaml
+controller:
+  type: neural_net
+  max_accel: 0.01      # should match the training config
+  weights: nn_controller_weights.npy
+```
+
+You can place this in a new YAML file (e.g., `configs/leo_nn.yaml`) or override fields from the command line.
+
+Run a simulation:
+
+```bash
+PYTHONPATH=src python sims/run_leo_100km.py --config configs/leo_nn.yaml
+```
+
+To directly evaluate the FOM of the trained controller:
+
+```bash
+PYTHONPATH=src python sims/run_fom_scenarios.py --controller neural_net --override controller.weights=nn_controller_weights.npy
+```
+
+This prints the FOM achieved by the neural controller.

--- a/sims/train_nn_controller.py
+++ b/sims/train_nn_controller.py
@@ -1,0 +1,102 @@
+"""Random-search training for the neural-network controller."""
+
+from __future__ import annotations
+
+import argparse
+import numpy as np
+import yaml
+
+from tskb import Environment, DualBarbell, diagnostics
+from tskb.controller import NeuralNetController
+from tskb.integrate import run_simulation
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="configs/leo_100km.yaml",
+        help="Base simulation config YAML",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=20,
+        help="Number of random-search iterations",
+    )
+    parser.add_argument(
+        "--noise",
+        type=float,
+        default=0.1,
+        help="Standard deviation of parameter noise",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="nn_controller_weights.npy",
+        help="File to save best parameters",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="Total simulation time in seconds (default: two orbits)",
+    )
+    parser.add_argument(
+        "--fom-time",
+        type=float,
+        default=None,
+        help="Time offset for FOM evaluation in seconds",
+    )
+    return parser.parse_args()
+
+
+def evaluate(env, craft, ctrl, cfg, fom_time, params) -> float:
+    ctrl.set_parameters(params)
+    log = run_simulation(env, craft, ctrl, cfg)
+    return diagnostics.semimajor_axis_fom(log, month=fom_time)
+
+
+def main() -> None:
+    args = parse_args()
+
+    with open(args.config, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    env = Environment()
+    craft = DualBarbell(cfg["mass"])
+
+    r0_mag = env.r_earth + cfg["altitude_m"]
+    period = 2 * np.pi * np.sqrt(r0_mag**3 / env.mu_earth)
+
+    duration = args.duration if args.duration is not None else 2 * period
+    dt = cfg["integrator"]["dt_output"]
+    cfg["integrator"]["t_final"] = float(np.ceil(duration / dt) * dt)
+
+    fom_time = args.fom_time if args.fom_time is not None else min(period, duration / 2)
+
+    ctrl_cfg = cfg.get("controller", {})
+    ctrl_cfg["type"] = "neural_net"
+    ctrl = NeuralNetController(ctrl_cfg)
+
+    best_params = ctrl.get_parameters()
+    best_score = evaluate(env, craft, ctrl, cfg, fom_time, best_params)
+    noise = args.noise
+    for i in range(args.iterations):
+        cand = best_params + noise * np.random.randn(best_params.size)
+        score = evaluate(env, craft, ctrl, cfg, fom_time, cand)
+        if score > best_score:
+            best_score = score
+            best_params = cand
+            noise *= 0.9
+        else:
+            noise *= 1.1
+        print(f"iter {i}: FOM={score:.3f}, best={best_score:.3f}")
+
+    np.save(args.output, best_params)
+    print(f"Saved best parameters to {args.output}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual script
+    main()

--- a/src/tskb/__init__.py
+++ b/src/tskb/__init__.py
@@ -2,7 +2,12 @@
 
 from .env import Environment
 from .barbell import DualBarbell, Q_of_barbell
-from .controller import BangBangController, PassiveController, make_controller
+from .controller import (
+    BangBangController,
+    PassiveController,
+    NeuralNetController,
+    make_controller,
+)
 from .integrate import run_simulation
 from . import diagnostics
 
@@ -12,6 +17,7 @@ __all__ = [
     "Q_of_barbell",
     "BangBangController",
     "PassiveController",
+    "NeuralNetController",
     "make_controller",
     "run_simulation",
     "diagnostics",

--- a/src/tskb/controller.py
+++ b/src/tskb/controller.py
@@ -142,6 +142,72 @@ class PassiveController(Controller):
         return 0.0
 
 
+class NeuralNetController(Controller):
+    """Feedforward neural-network controller.
+
+    The network maps the full 10-element state vector to a commanded
+    tether acceleration.  Hidden layers use ``tanh`` activations and the
+    final output is clipped to ``±max_accel``.  Parameters are stored as a
+    flat vector to enable simple optimization strategies.
+    """
+
+    def __init__(self, cfg: dict | None = None) -> None:
+        cfg = cfg or {}
+        self.max_accel = float(cfg.get("max_accel", 0.01))
+        self.hidden_sizes = [int(h) for h in cfg.get("hidden_sizes", [16, 16])]
+        self.rng = np.random.default_rng(cfg.get("seed"))
+        layer_sizes = [10] + self.hidden_sizes + [1]
+
+        self.layers: list[tuple[np.ndarray, np.ndarray]] = []
+        scale = float(cfg.get("weight_scale", 0.1))
+        for in_size, out_size in zip(layer_sizes[:-1], layer_sizes[1:]):
+            w = self.rng.normal(0.0, scale, size=(out_size, in_size))
+            b = np.zeros(out_size)
+            self.layers.append((w, b))
+
+        if "weights" in cfg:
+            weights = np.load(cfg["weights"])
+            self.set_parameters(weights)
+
+    # ------------------------------------------------------------------
+    # Parameter helpers
+    def get_parameters(self) -> np.ndarray:
+        """Return flattened parameter vector."""
+
+        parts = []
+        for w, b in self.layers:
+            parts.append(w.ravel())
+            parts.append(b.ravel())
+        return np.concatenate(parts)
+
+    def set_parameters(self, flat: np.ndarray) -> None:
+        """Set network parameters from a flat array."""
+
+        idx = 0
+        new_layers = []
+        for w, b in self.layers:
+            w_size = w.size
+            b_size = b.size
+            w_shape = w.shape
+            b_shape = b.shape
+            w = flat[idx : idx + w_size].reshape(w_shape)
+            idx += w_size
+            b = flat[idx : idx + b_size].reshape(b_shape)
+            idx += b_size
+            new_layers.append((w, b))
+        self.layers = new_layers
+
+    # ------------------------------------------------------------------
+    def action(self, t: float, state: np.ndarray) -> float:
+        x = np.asarray(state, dtype=float)
+        for i, (w, b) in enumerate(self.layers):
+            x = w @ x + b
+            if i < len(self.layers) - 1:
+                x = np.tanh(x)
+        out = float(x.squeeze())
+        return float(np.clip(out, -self.max_accel, self.max_accel))
+
+
 def make_controller(cfg: dict) -> Controller:
     """Instantiate a controller from ``cfg``.
 
@@ -157,4 +223,6 @@ def make_controller(cfg: dict) -> Controller:
         return BangBangController(cfg)
     if ctrl_type == "passive":
         return PassiveController()
+    if ctrl_type == "neural_net":
+        return NeuralNetController(cfg)
     raise ValueError(f"unknown controller type: {ctrl_type}")

--- a/tests/test_controller_interface.py
+++ b/tests/test_controller_interface.py
@@ -1,5 +1,5 @@
 import numpy as np
-from tskb.controller import BangBangController, PassiveController
+from tskb.controller import BangBangController, PassiveController, NeuralNetController
 
 
 def test_controller_action_interface():
@@ -9,4 +9,6 @@ def test_controller_action_interface():
     action = BangBangController(cfg).action(0.0, state)
     assert isinstance(action, float)
     action = PassiveController().action(0.0, state)
+    assert isinstance(action, float)
+    action = NeuralNetController({"max_accel": 1.0}).action(0.0, state)
     assert isinstance(action, float)


### PR DESCRIPTION
## Summary
- document training and use of the neural-network controller

## Testing
- `PYTHONPATH=src python -m pytest -q`
- `PYTHONPATH=src python sims/train_nn_controller.py --iterations 1 --noise 0.05 --output temp_weights.npy`


------
https://chatgpt.com/codex/tasks/task_e_68ad1a66602c83228e97d1bc4077ac86