### PR TITLE
Add safety checks and PI-based MoonAngle control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,13 @@ acceleration command.
 ### Moon Angle Controller
 
 * **File**: `src/tskb/controller.py`
-* **Description**: Commands tether acceleration using ``max_accel * cos(2*(\theta - offset))`` where ``\theta`` is the angle between the Moon and barbell center of mass. Acceleration is zeroed once the tether reaches 80 km during contraction or 110 km during extension. A phase offset ``offset_rad`` allows sweeping different schedules.
-* **Use Case**: Explore angle-based acceleration schedules.
+* **Description**: Tracks a Moon-relative length schedule with a PI loop.  The
+  desired tether length is ``L_des = L_mid + L_amp * cos(2*(\theta - offset))``
+  where ``\theta`` is the angle between the Moon and barbell center of mass.
+  Acceleration commands are limited to ``±max_accel`` and zeroed once the tether
+  reaches 80 km during contraction or 110 km during extension.  A phase offset
+  ``offset_rad`` allows sweeping different schedules.
+* **Use Case**: Explore angle-based length schedules.
 * **Run Example**:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,12 +33,13 @@ acceleration command.
 ### Moon Angle Controller
 
 * **File**: `src/tskb/controller.py`
-* **Description**: Tracks a Moon-relative length schedule with a PI loop.  The
-  desired tether length is ``L_des = L_mid + L_amp * cos(2*(\theta - offset))``
-  where ``\theta`` is the angle between the Moon and barbell center of mass.
-  Acceleration commands are limited to ``±max_accel`` and zeroed once the tether
-  reaches 80 km during contraction or 110 km during extension.  A phase offset
-  ``offset_rad`` allows sweeping different schedules.
+* **Description**: Tracks a Moon-relative length schedule with a PID loop and
+  velocity damping.  The desired tether length is
+  ``L_des = L_mid + L_amp * cos(2*(\theta - offset))`` where ``\theta`` is the
+  angle between the Moon and barbell center of mass.  Acceleration commands are
+  limited to ``±max_accel`` and zeroed once the tether reaches 80 km during
+  contraction or 110 km during extension.  A phase offset ``offset_rad`` allows
+  sweeping different schedules.
 * **Use Case**: Explore angle-based length schedules.
 * **Run Example**:
 

--- a/src/tskb/__init__.py
+++ b/src/tskb/__init__.py
@@ -10,7 +10,12 @@ from .controller import (
     MoonAngleController,
     make_controller,
 )
-from .integrate import run_simulation, SimulationError
+from .integrate import (
+    run_simulation,
+    SimulationError,
+    TetherTooShortError,
+    SpinReversalError,
+)
 from . import diagnostics
 
 __all__ = [
@@ -25,5 +30,7 @@ __all__ = [
     "make_controller",
     "run_simulation",
     "SimulationError",
+    "TetherTooShortError",
+    "SpinReversalError",
     "diagnostics",
 ]

--- a/src/tskb/controller.py
+++ b/src/tskb/controller.py
@@ -168,15 +168,16 @@ class LandisController(Controller):
 
 
 class MoonAngleController(Controller):
-    """PI controller tracking a Moon-relative length schedule."""
+    """PID controller tracking a Moon-relative length schedule."""
 
     def __init__(self, cfg: dict) -> None:
         self.max_accel = float(cfg.get("max_accel", 0.01))
         self.offset_rad = float(cfg.get("offset_rad", 0.0))
         self.extend_limit = float(cfg.get("extend_limit_m", 110_000.0))
         self.retract_limit = float(cfg.get("retract_limit_m", 80_000.0))
-        self.kp = float(cfg.get("kp", 1e-4))
-        self.ki = float(cfg.get("ki", 1e-6))
+        self.kp = float(cfg.get("kp", 5e-5))
+        self.ki = float(cfg.get("ki", 1e-8))
+        self.kd = float(cfg.get("kd", 1e-1))
         self._int_err = 0.0
         self._last_t: float | None = None
 
@@ -200,7 +201,8 @@ class MoonAngleController(Controller):
             dt = t - self._last_t
         self._last_t = t
         self._int_err += err * dt
-        accel = self.kp * err + self.ki * self._int_err
+        Ldot = state[9]
+        accel = self.kp * err + self.ki * self._int_err - self.kd * Ldot
         accel = np.clip(accel, -self.max_accel, self.max_accel)
         if accel > 0.0 and L >= self.extend_limit:
             return 0.0

--- a/src/tskb/controller.py
+++ b/src/tskb/controller.py
@@ -168,13 +168,17 @@ class LandisController(Controller):
 
 
 class MoonAngleController(Controller):
-    """Controller scheduling acceleration by Moon-relative angle."""
+    """PI controller tracking a Moon-relative length schedule."""
 
     def __init__(self, cfg: dict) -> None:
         self.max_accel = float(cfg.get("max_accel", 0.01))
         self.offset_rad = float(cfg.get("offset_rad", 0.0))
         self.extend_limit = float(cfg.get("extend_limit_m", 110_000.0))
         self.retract_limit = float(cfg.get("retract_limit_m", 80_000.0))
+        self.kp = float(cfg.get("kp", 1e-4))
+        self.ki = float(cfg.get("ki", 1e-6))
+        self._int_err = 0.0
+        self._last_t: float | None = None
 
     def action(self, t: float, state: np.ndarray, env: Environment) -> float:  # noqa: D401
         """Return commanded tether acceleration ``L_ddot``."""
@@ -184,7 +188,20 @@ class MoonAngleController(Controller):
         theta_r = np.arctan2(r[1], r[0])
         theta_m = np.arctan2(moon_r[1], moon_r[0])
         theta = theta_r - theta_m
-        accel = self.max_accel * np.cos(2.0 * (theta - self.offset_rad))
+
+        L_mid = 0.5 * (self.extend_limit + self.retract_limit)
+        L_amp = 0.5 * (self.extend_limit - self.retract_limit)
+        L_des = L_mid + L_amp * np.cos(2.0 * (theta - self.offset_rad))
+
+        err = L_des - L
+        if self._last_t is None:
+            dt = 0.0
+        else:
+            dt = t - self._last_t
+        self._last_t = t
+        self._int_err += err * dt
+        accel = self.kp * err + self.ki * self._int_err
+        accel = np.clip(accel, -self.max_accel, self.max_accel)
         if accel > 0.0 and L >= self.extend_limit:
             return 0.0
         if accel < 0.0 and L <= self.retract_limit:

--- a/src/tskb/integrate.py
+++ b/src/tskb/integrate.py
@@ -16,6 +16,14 @@ class SimulationError(RuntimeError):
         self.log = log
 
 
+class TetherTooShortError(SimulationError):
+    """Raised when the tether length drops below the safety threshold."""
+
+
+class SpinReversalError(SimulationError):
+    """Raised when the barbell reverses its spin direction."""
+
+
 def run_simulation(env, craft, ctrl, cfg: dict) -> dict:
     """Run a simulation and return a log dictionary."""
 
@@ -101,14 +109,45 @@ def run_simulation(env, craft, ctrl, cfg: dict) -> dict:
     }
 
     r_mag = np.linalg.norm(r, axis=1)
+
+    # Gather potential failure events
+    events: list[tuple[str, float, int]] = []
     if np.min(r_mag) < env.r_earth:
         i_hit = int(np.argmin(r_mag))
-        alt = r_mag[i_hit] - env.r_earth
-        # Truncate logs up to the collision index
+        events.append(("earth", sol.t[i_hit], i_hit))
+
+    min_length = 10_000.0
+    below = np.where(length < min_length)[0]
+    if length[0] > min_length and below.size:
+        i_short = int(below[0])
+        events.append(("short", sol.t[i_short], i_short))
+
+    sign0 = np.sign(omega[0])
+    if sign0 != 0.0:
+        rev = np.where(omega[1:] * sign0 < 0.0)[0]
+        if rev.size:
+            i_rev = int(rev[0] + 1)
+            events.append(("spin", sol.t[i_rev], i_rev))
+
+    if events:
+        kind, t_evt, idx = min(events, key=lambda e: e[1])
         for k, v_arr in log.items():
-            log[k] = v_arr[: i_hit + 1]
-        raise SimulationError(
-            f"simulation crashed into Earth at t={sol.t[i_hit]:.3f}s, altitude={alt:.1f} m",
+            log[k] = v_arr[: idx + 1]
+        if kind == "earth":
+            alt = r_mag[idx] - env.r_earth
+            raise SimulationError(
+                f"simulation crashed into Earth at t={t_evt:.3f}s, altitude={alt:.1f} m",
+                log,
+            )
+        if kind == "short":
+            log["length"][-1] = min_length
+            log["length_rate"][-1] = 0.0
+            raise TetherTooShortError(
+                f"tether length dropped below 10 km at t={t_evt:.3f}s",
+                log,
+            )
+        raise SpinReversalError(
+            f"angular velocity reversed sign at t={t_evt:.3f}s",
             log,
         )
 


### PR DESCRIPTION
## Summary
- add `TetherTooShortError` and `SpinReversalError` to halt simulations when tether collapses below 10 km or spin reverses
- implement PI-controlled MoonAngle controller that tracks desired length schedule
- document MoonAngle controller behavior

## Testing
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python sims/run_leo_100km.py --config configs/leo_100km.yaml` *(fails: tether length dropped below 10 km at t=6520.000s)*

------
https://chatgpt.com/codex/tasks/task_e_68b251238db88322b632446a8145f864