### PR TITLE
Add diamond craft with passive passive controller

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,13 @@ acceleration command.
 * **Description**: No active control; the system evolves only under natural dynamics.
 * **Use Case**: Baseline for comparison against active controllers. An active controller may not be needed.
 
+### Diamond Passive Controller
+
+* **File**: `src/tskb/controller.py`
+* **Description**: Initializes a four-mass diamond craft at the Earth–Moon L1
+  point with the masses fixed 100 km apart. No active control is applied.
+* **Use Case**: Baseline simulation of a rigid diamond tether configuration.
+
 ### Landis Controller
 
 * **File**: `src/tskb/controller.py`

--- a/src/tskb/__init__.py
+++ b/src/tskb/__init__.py
@@ -4,6 +4,7 @@ from .env import Environment
 from .barbell import DualBarbell, Q_of_barbell
 from .point import PointMass
 from .kite import Kite
+from .diamond import Diamond
 from .craft import make_craft
 from .controller import (
     BangBangController,
@@ -27,6 +28,7 @@ __all__ = [
     "DualBarbell",
     "Q_of_barbell",
     "Kite",
+    "Diamond",
     "make_craft",
     "BangBangController",
     "PassiveController",

--- a/src/tskb/controller.py
+++ b/src/tskb/controller.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from .env import Environment
 from .barbell import DualBarbell
+from .diamond import Diamond
 
 
 class Controller:
@@ -192,6 +193,9 @@ class PassiveController(Controller):
         v0_mag = np.sqrt(env.mu_earth / r0_mag)
         r = np.array([r0_mag, 0.0, 0.0])
         v = np.array([0.0, v0_mag, 0.0])
+        if isinstance(craft, Diamond):
+            r = env.l1_position(0.0)
+            v = np.cross(np.array([0.0, 0.0, env.n_moon]), r)
         if isinstance(craft, DualBarbell):
             n0 = np.sqrt(env.mu_earth / r0_mag**3)
             n_syn = n0 - env.n_moon

--- a/src/tskb/craft.py
+++ b/src/tskb/craft.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .barbell import DualBarbell
 from .point import PointMass
 from .kite import Kite
+from .diamond import Diamond
 
 
 def make_craft(cfg: dict):
@@ -13,9 +14,9 @@ def make_craft(cfg: dict):
     Parameters
     ----------
     cfg : dict
-        Must contain a ``type`` key of ``"barbell"``, ``"point"`` or ``"kite"``
-        and a ``mass`` value.  Additional keys are passed through to the
-        specific craft constructor where applicable.
+        Must contain a ``type`` key of ``"barbell"``, ``"point"``, ``"kite"``
+        or ``"diamond"`` and a ``mass`` value.  Additional keys are passed
+        through to the specific craft constructor where applicable.
     """
 
     craft_type = cfg.get("type", "barbell").lower()
@@ -30,5 +31,7 @@ def make_craft(cfg: dict):
         return PointMass(mass)
     if craft_type == "kite":
         return Kite(mass)
+    if craft_type == "diamond":
+        return Diamond(mass, diameter=float(cfg.get("diameter", 100_000.0)))
     raise ValueError(f"unknown craft type: {craft_type}")
 

--- a/src/tskb/diamond.py
+++ b/src/tskb/diamond.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+class Diamond:
+    """Rigid four-mass diamond configuration.
+
+    Four equal masses are connected by massless tethers forming a diamond
+    within the Moon's orbital plane.  The structure maintains a fixed
+    diameter; controllers may later adjust the spacing by returning a scaling
+    factor from :func:`action`.
+    """
+
+    def __init__(self, mass: float, diameter: float = 100e3) -> None:
+        self.mass = mass
+        self.diameter = float(diameter)
+
+    def dynamics(self, t: float, y: np.ndarray, env, ctrl) -> np.ndarray:
+        """Return time derivative of the state vector ``y``.
+
+        The state comprises ``[r(3), v(3)]`` for the craft centre of mass.
+        Offsets of individual masses remain fixed at half the diameter in the
+        ``±x`` and ``±y`` directions.  The controller's action is currently
+        ignored but provides a placeholder for future spacing adjustments.
+        """
+
+        if not np.isfinite(y).all():
+            raise RuntimeError("non-finite state in dynamics")
+
+        r = y[0:3]
+        v = y[3:6]
+
+        # Placeholder for future control over spacing
+        ctrl.action(t, y, env)
+
+        d = 0.5 * self.diameter
+        offsets = np.array(
+            [
+                [ d, 0.0, 0.0],
+                [-d, 0.0, 0.0],
+                [0.0,  d, 0.0],
+                [0.0, -d, 0.0],
+            ]
+        )
+
+        acc = np.zeros(3)
+        for off in offsets:
+            ri = r + off
+            acc += env.a_earth(ri) + env.a_moon_tide(ri, t)
+        a_com = acc / 4.0
+
+        return np.hstack([v, a_com])

--- a/src/tskb/env.py
+++ b/src/tskb/env.py
@@ -37,6 +37,14 @@ class Environment:
         phase = self.n_moon * t
         return self.r_moon * np.array([np.cos(phase), np.sin(phase), 0.0])
 
+    def l1_position(self, t: float = 0.0) -> np.ndarray:
+        """Approximate Earth–Moon L1 point in an inertial frame."""
+
+        mu = self.mu_moon / (self.mu_earth + self.mu_moon)
+        x = self.r_moon * (1.0 - (mu / 3.0) ** (1.0 / 3.0))
+        phase = self.n_moon * t
+        return x * np.array([np.cos(phase), np.sin(phase), 0.0])
+
     def a_earth(self, r: np.ndarray) -> np.ndarray:
         """Point-mass acceleration from Earth."""
         d = np.linalg.norm(r)

--- a/tests/test_diamond_sim.py
+++ b/tests/test_diamond_sim.py
@@ -1,0 +1,17 @@
+import numpy as np
+from tskb import Environment, make_controller, make_craft, run_simulation
+
+
+def test_diamond_passive_runs():
+    cfg = {
+        "craft": {"type": "diamond", "mass": 1000.0},
+        "controller": {"type": "passive"},
+        "integrator": {"t_final": 10.0, "dt_output": 5.0},
+    }
+    env = Environment()
+    craft = make_craft(cfg["craft"])
+    ctrl = make_controller(cfg["controller"])
+    log = run_simulation(env, craft, ctrl, cfg)
+    r0 = env.l1_position(0.0)
+    assert np.allclose(log["r"][0], r0)
+    assert log["r"].shape[0] == log["t"].size


### PR DESCRIPTION
## Summary
- add new `Diamond` craft representing four tethered masses with fixed 100 km diameter
- extend environment and passive controller to start diamond at Earth–Moon L1
- document controller and add tests for passive diamond simulation

## Testing
- `pre-commit run --files AGENTS.md src/tskb/diamond.py src/tskb/env.py src/tskb/controller.py src/tskb/craft.py src/tskb/__init__.py tests/test_diamond_sim.py`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0e633329083228f772b553c142a85