### PR TITLE
Add diamond L1 stabilizer controller

### DIFF
--- a/docs/diamond_l1_stabilizer.md
+++ b/docs/diamond_l1_stabilizer.md
@@ -1,0 +1,17 @@
+# Diamond L1 Stabilizer
+
+The diamond L1 stabilizer controller suppresses the unstable mode of the
+Earth–Moon L1 equilibrium point by deforming the kite-shaped craft. The
+controller projects the hub state into the rotating Earth–Moon frame and
+measures displacement and velocity along the linearized unstable eigenvector
+of the circular restricted three-body problem. A proportional–derivative law
+produces a commanded stretch of the X-axis tethers: the X± masses are driven
+outward while the Y± masses are pulled inward by the same amount. This oblate
+quadrupole biases the combined gravitational acceleration back toward L1 and
+keeps the craft from diverging along the Earth–Moon line.
+
+Secondary trims are not yet implemented. The intended roadmap is to bias the
+Y-axis masses in response to lateral hub velocity (providing gentle tangential
+damping) and to modulate the diagonal linkages to counter residual torques.
+Those trims will be incorporated in future work once the primary unstable-axis
+loop is fully characterized.

--- a/src/tskb/__init__.py
+++ b/src/tskb/__init__.py
@@ -12,6 +12,7 @@ from .controller import (
     NeuralNetController,
     LandisController,
     MoonAngleController,
+    DiamondL1Stabilizer,
     make_controller,
 )
 from .integrate import (
@@ -34,6 +35,7 @@ __all__ = [
     "PassiveController",
     "LandisController",
     "MoonAngleController",
+    "DiamondL1Stabilizer",
     "NeuralNetController",
     "make_controller",
     "run_simulation",

--- a/src/tskb/controller.py
+++ b/src/tskb/controller.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 
 from .env import Environment
 from .barbell import DualBarbell
-from .diamond import Diamond
+from .diamond import Diamond, DiamondControlCommand
+from .cr3bp import l1_unstable_mode
 
 
 class Controller:
@@ -196,6 +197,10 @@ class PassiveController(Controller):
         if isinstance(craft, Diamond):
             r = env.l1_position(0.0)
             v = np.cross(np.array([0.0, 0.0, env.n_moon]), r)
+            vx0 = float(init_cfg.get("vx0", 0.0))
+            vy0 = float(init_cfg.get("vy0", 0.0))
+            vz0 = float(init_cfg.get("vz0", 0.0))
+            v = v + np.array([vx0, vy0, vz0])
         if isinstance(craft, DualBarbell):
             n0 = np.sqrt(env.mu_earth / r0_mag**3)
             n_syn = n0 - env.n_moon
@@ -218,6 +223,98 @@ class PassiveController(Controller):
             Ldot0 = init_cfg.get("length_rate0", 0.0)
             return np.hstack([r, v, theta0, omega0, L0, Ldot0])
         return np.hstack([r, v])
+
+
+class DiamondL1Stabilizer(Controller):
+    """PD stabilizer for the diamond craft about the Earth–Moon L1 point."""
+
+    def __init__(self, cfg: dict) -> None:
+        self.kp = float(cfg.get("kp", 5.0e-2))
+        self.kd = float(cfg.get("kd", 5.0e-1))
+        self.ku = max(float(cfg.get("ku", 2.0e-3)), 1e-6)
+        self.delta_limit = float(cfg.get("delta_limit_m", 150_000.0))
+        self.delta_rate = float(cfg.get("delta_rate_limit_mps", 80.0))
+
+        self._mode = None
+        self._x_l1 = None
+        self._delta = 0.0
+        self._last_t: float | None = None
+
+    @staticmethod
+    def _rotation(theta: float) -> np.ndarray:
+        c = float(np.cos(theta))
+        s = float(np.sin(theta))
+        return np.array(
+            [
+                [c, s, 0.0],
+                [-s, c, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+
+    def _ensure_mode(self, env: Environment) -> None:
+        if self._mode is not None:
+            return
+        mu = env.mu_moon / (env.mu_earth + env.mu_moon)
+        self._mode = l1_unstable_mode(mu, env.r_moon, env.n_moon)
+        self._x_l1 = (self._mode.x_l1_bary + mu) * env.r_moon
+
+    def _l1_position(self, theta: float) -> np.ndarray:
+        assert self._x_l1 is not None
+        x = float(self._x_l1)
+        c = float(np.cos(theta))
+        s = float(np.sin(theta))
+        return np.array([x * c, x * s, 0.0])
+
+    def initial_state(self, env: Environment, craft, cfg: dict) -> np.ndarray:  # noqa: D401
+        self._ensure_mode(env)
+        ctrl_cfg = cfg.get("controller", {})
+        init_cfg = ctrl_cfg.get("initial", {})
+        theta0 = float(init_cfg.get("theta0", 0.0))
+        r = self._l1_position(theta0)
+        omega_vec = np.array([0.0, 0.0, env.n_moon])
+        v = np.cross(omega_vec, r)
+        vx0 = float(init_cfg.get("vx0", 0.0))
+        vy0 = float(init_cfg.get("vy0", 0.0))
+        vz0 = float(init_cfg.get("vz0", 0.0))
+        v = v + np.array([vx0, vy0, vz0])
+        return np.hstack([r, v])
+
+    def action(self, t: float, state: np.ndarray, env: Environment) -> DiamondControlCommand:
+        self._ensure_mode(env)
+        assert self._mode is not None
+        assert self._x_l1 is not None
+
+        r = state[0:3]
+        v = state[3:6]
+
+        theta = env.n_moon * t
+        rot = self._rotation(theta)
+        r_l1 = self._l1_position(theta)
+        delta_r = rot @ (r - r_l1)
+
+        omega_vec = np.array([0.0, 0.0, env.n_moon])
+        v_rel = v - np.cross(omega_vec, r)
+        delta_v = rot @ v_rel
+
+        q = float(self._mode.pos_dir @ delta_r[0:2])
+        qdot = float(self._mode.vel_dir @ delta_v[0:2])
+
+        u = -self.kp * q - self.kd * qdot
+        delta_des = np.clip(u / self.ku, -self.delta_limit, self.delta_limit)
+
+        if self._last_t is None:
+            delta = delta_des
+        else:
+            dt = t - self._last_t
+            if dt <= 0.0:
+                delta = self._delta
+            else:
+                max_change = self.delta_rate * dt
+                delta = np.clip(delta_des, self._delta - max_change, self._delta + max_change)
+        self._delta = float(np.clip(delta, -self.delta_limit, self.delta_limit))
+        self._last_t = float(t)
+        return DiamondControlCommand(stretch=self._delta)
 
 
 class LandisController(BarbellControllerBase):
@@ -381,4 +478,6 @@ def make_controller(cfg: dict) -> Controller:
         return MoonAngleController(cfg)
     if ctrl_type == "neural_net":
         return NeuralNetController(cfg)
+    if ctrl_type == "diamond_l1_stabilizer":
+        return DiamondL1Stabilizer(cfg)
     raise ValueError(f"unknown controller type: {ctrl_type}")

--- a/src/tskb/cr3bp.py
+++ b/src/tskb/cr3bp.py
@@ -1,0 +1,114 @@
+"""Utilities for working with the circular restricted three-body problem."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy import optimize
+
+
+@dataclass(frozen=True)
+class L1UnstableMode:
+    """Representation of the planar unstable mode about the L1 point."""
+
+    eigenvalue: float
+    right: np.ndarray
+    left: np.ndarray
+    pos_dir: np.ndarray
+    vel_dir: np.ndarray
+    pos_scale: float
+    vel_scale: float
+    x_l1_bary: float
+
+
+def _solve_l1_barycentric(mu: float) -> float:
+    """Return the barycentric ``x`` location of the L1 libration point."""
+
+    def f(x: float) -> float:
+        r1 = abs(x + mu)
+        r2 = abs(x - 1.0 + mu)
+        term1 = (1.0 - mu) * (x + mu) / r1**3
+        term2 = mu * (x - 1.0 + mu) / r2**3
+        return x - term1 - term2
+
+    # Close-form approximation is sufficient as a starting guess.
+    x0 = 1.0 - (mu / 3.0) ** (1.0 / 3.0)
+    return float(optimize.newton(f, x0))
+
+
+def _l1_state_matrix(x_l1: float, mu: float) -> np.ndarray:
+    """Return planar CR3BP state matrix about L1 in normalized units."""
+
+    r1 = abs(x_l1 + mu)
+    r2 = abs(x_l1 - 1.0 + mu)
+
+    omega_xx = (
+        1.0
+        - (1.0 - mu) / r1**3
+        + 3.0 * (1.0 - mu) * (x_l1 + mu) ** 2 / r1**5
+        - mu / r2**3
+        + 3.0 * mu * (x_l1 - 1.0 + mu) ** 2 / r2**5
+    )
+    omega_yy = 1.0 - (1.0 - mu) / r1**3 - mu / r2**3
+
+    A = np.array(
+        [
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+            [omega_xx, 0.0, 0.0, 2.0],
+            [0.0, omega_yy, -2.0, 0.0],
+        ]
+    )
+    return A
+
+
+def l1_unstable_mode(mu: float, distance: float, rotation_rate: float) -> L1UnstableMode:
+    """Return the unstable eigenmode about the L1 point in physical units."""
+
+    x_l1 = _solve_l1_barycentric(mu)
+    A = _l1_state_matrix(x_l1, mu)
+
+    eigvals, eigvecs = np.linalg.eig(A)
+    idx = int(np.argmax(eigvals.real))
+    eigval = float(eigvals[idx].real)
+    right = np.asarray(eigvecs[:, idx].real)
+
+    eigvals_left, eigvecs_left = np.linalg.eig(A.T)
+    idx_left = int(np.argmin(np.abs(eigvals_left - eigvals[idx])))
+    left = np.asarray(eigvecs_left[:, idx_left].real)
+
+    dot = float(left @ right)
+    if dot == 0.0:
+        raise RuntimeError("degenerate eigenvectors for L1 linearization")
+    left /= dot
+
+    S_inv = np.diag([distance, distance, distance * rotation_rate, distance * rotation_rate])
+    S = np.diag([1.0 / distance, 1.0 / distance, 1.0 / (distance * rotation_rate), 1.0 / (distance * rotation_rate)])
+
+    right_phys = S_inv @ right
+    left_phys = S @ left
+
+    pos_vec = right_phys[:2].copy()
+    vel_vec = right_phys[2:].copy()
+    sign = 1.0 if pos_vec[0] >= 0.0 else -1.0
+    pos_vec *= sign
+    vel_vec *= sign
+    pos_norm = float(np.linalg.norm(pos_vec))
+    vel_norm = float(np.linalg.norm(vel_vec))
+    if pos_norm == 0.0 or vel_norm == 0.0:
+        raise RuntimeError("invalid eigenvector for L1 mode")
+    pos_dir = pos_vec / pos_norm
+    vel_dir = vel_vec / vel_norm
+
+    return L1UnstableMode(
+        eigenvalue=eigval * rotation_rate,
+        right=right_phys,
+        left=left_phys,
+        pos_dir=pos_dir,
+        vel_dir=vel_dir,
+        pos_scale=pos_norm,
+        vel_scale=vel_norm,
+        x_l1_bary=x_l1,
+    )
+

--- a/src/tskb/diamond.py
+++ b/src/tskb/diamond.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
+
+
+@dataclass
+class DiamondControlCommand:
+    """Controller command describing the diamond's planar deformation."""
+
+    stretch: float = 0.0
 
 
 class Diamond:
@@ -20,9 +29,9 @@ class Diamond:
         """Return time derivative of the state vector ``y``.
 
         The state comprises ``[r(3), v(3)]`` for the craft centre of mass.
-        Offsets of individual masses remain fixed at half the diameter in the
-        ``±x`` and ``±y`` directions.  The controller's action is currently
-        ignored but provides a placeholder for future spacing adjustments.
+        Offsets of individual masses start at half the diameter in the
+        ``±x`` and ``±y`` directions and may be stretched or compressed by
+        the controller via :class:`DiamondControlCommand`.
         """
 
         if not np.isfinite(y).all():
@@ -31,16 +40,21 @@ class Diamond:
         r = y[0:3]
         v = y[3:6]
 
-        # Placeholder for future control over spacing
-        ctrl.action(t, y, env)
+        cmd = ctrl.action(t, y, env)
+        stretch = 0.0
+        if isinstance(cmd, DiamondControlCommand):
+            stretch = float(cmd.stretch)
 
         d = 0.5 * self.diameter
+        dx = max(d + 0.5 * stretch, 0.0)
+        dy = max(d - 0.5 * stretch, 0.0)
+
         offsets = np.array(
             [
-                [ d, 0.0, 0.0],
-                [-d, 0.0, 0.0],
-                [0.0,  d, 0.0],
-                [0.0, -d, 0.0],
+                [ dx, 0.0, 0.0],
+                [-dx, 0.0, 0.0],
+                [0.0,  dy, 0.0],
+                [0.0, -dy, 0.0],
             ]
         )
 

--- a/tests/test_diamond_sim.py
+++ b/tests/test_diamond_sim.py
@@ -1,5 +1,7 @@
+import copy
 import numpy as np
 from tskb import Environment, make_controller, make_craft, run_simulation
+from tskb.cr3bp import l1_unstable_mode
 
 
 def test_diamond_passive_runs():
@@ -15,3 +17,47 @@ def test_diamond_passive_runs():
     r0 = env.l1_position(0.0)
     assert np.allclose(log["r"][0], r0)
     assert log["r"].shape[0] == log["t"].size
+
+
+def _project_along_em_axis(env: Environment, log: dict, x_l1: float) -> np.ndarray:
+    offsets = []
+    for t, r in zip(log["t"], log["r"]):
+        theta = env.n_moon * t
+        c, s = np.cos(theta), np.sin(theta)
+        rot = np.array([[c, s, 0.0], [-s, c, 0.0], [0.0, 0.0, 1.0]])
+        r_l1 = np.array([x_l1 * c, x_l1 * s, 0.0])
+        offsets.append((rot @ (r - r_l1))[0])
+    return np.asarray(offsets)
+
+
+def test_diamond_stabilizer_reduces_drift():
+    env = Environment()
+    craft_cfg = {"type": "diamond", "mass": 1000.0}
+    integrator_cfg = {"t_final": 24 * 3600.0, "dt_output": 1800.0}
+    initial_cfg = {"vx0": -0.5}
+
+    mu = env.mu_moon / (env.mu_earth + env.mu_moon)
+    mode = l1_unstable_mode(mu, env.r_moon, env.n_moon)
+    x_l1 = (mode.x_l1_bary + mu) * env.r_moon
+
+    def run(ctrl_cfg: dict) -> np.ndarray:
+        cfg = {
+            "craft": copy.deepcopy(craft_cfg),
+            "controller": copy.deepcopy(ctrl_cfg),
+            "integrator": copy.deepcopy(integrator_cfg),
+        }
+        craft = make_craft(cfg["craft"])
+        ctrl = make_controller(cfg["controller"])
+        log = run_simulation(env, craft, ctrl, cfg)
+        return _project_along_em_axis(env, log, x_l1)
+
+    passive_offsets = run({"type": "passive", "initial": initial_cfg})
+    stabilizer_offsets = run({
+        "type": "diamond_l1_stabilizer",
+        "initial": initial_cfg,
+    })
+
+    passive_max = float(np.max(np.abs(passive_offsets)))
+    stabilizer_max = float(np.max(np.abs(stabilizer_offsets)))
+
+    assert stabilizer_max < 0.4 * passive_max


### PR DESCRIPTION
## Summary
- introduce CR3BP utilities and a diamond L1 stabilizer controller that stretches the craft along the unstable eigenvector
- allow diamond dynamics to respond to control commands and support velocity perturbations in passive initial states
- document the stabilizer scheme and cover it with a drift comparison test

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc030ba3c483229e8e10c0b0a0344e